### PR TITLE
Remove actions/setup-node build step

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -17,11 +17,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Node toolchain
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-
       - name: Install Nodejs toolchain
         run: npm ci
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Node toolchain
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-
       - name: Lint and check formatting with prettier
         run: npx prettier --check '**/*'
 


### PR DESCRIPTION
This step has been flaky and it is not necessary because
the GitHub Actions base image ships with node 12.x.