### PR TITLE
Don't package source directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@artichokeruby/logo",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artichokeruby/logo",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Artichoke Ruby logo",
   "keywords": [
     "programming language",
@@ -25,8 +25,7 @@
     "img",
     "index.js",
     "optimized",
-    "social",
-    "source"
+    "social"
   ],
   "devDependencies": {},
   "eslintConfig": {


### PR DESCRIPTION
0.9.1 is 2.48MB on npm; let's slim that down. The sources are never used
for building, so don't publish those.

Bump package version to 0.9.2 and prep for release.