### PR TITLE
Update Audit GitHub Actions workflow

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -52,6 +52,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Generate Cargo.lock
+        run: |
+          if [[ ! -f "Cargo.lock" ]]; then
+            cargo generate-lockfile --verbose
+          fi
+
       - name: Setup cargo-deny
         run: |
           release_base="https://github.com/EmbarkStudios/cargo-deny/releases/download"


### PR DESCRIPTION
Managed by Terraform.

The cargo-deny version is 0.9.1.

Pushed commit 1e48513948dbea446769a5c2e4c735b394cb3fe2.
