### PR TITLE
Purge vestigial eslint config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,6 @@
   "devDependencies": {
     "prettier": "^3.1.1"
   },
-  "eslintConfig": {
-    "env": {
-      "browser": true,
-      "commonjs": true,
-      "es6": true,
-      "node": true
-    }
-  },
   "scripts": {
     "fmt": "prettier --write \"**/*\"",
     "fmt:sh": "shfmt -f . | grep -v node_modules | xargs shfmt -w -i 2 -ci -s",


### PR DESCRIPTION
This is a copy-paste legacy. This repo does not use eslint. This config is not valid for the latest version of eslint@9.